### PR TITLE
Fix `initialize_copy' openssl::cipher::ciphererror on Heroku 

### DIFF
--- a/lib/lite/encryption/schemes/deterministic.rb
+++ b/lib/lite/encryption/schemes/deterministic.rb
@@ -23,6 +23,7 @@ module Lite
           @cipher ||= begin
             Lite::Encryption::Key::CIPHER.dup
           rescue OpenSSL::Cipher::CipherError => e
+            puts e.message
             throw e unless e.message != 'not able to copy ctx'
 
             OpenSSL::Cipher.new('aes-256-gcm')

--- a/lib/lite/encryption/schemes/deterministic.rb
+++ b/lib/lite/encryption/schemes/deterministic.rb
@@ -20,7 +20,13 @@ module Lite
         private
 
         def cipher
-          @cipher ||= Lite::Encryption::Key::CIPHER.dup
+          @cipher ||= begin
+            Lite::Encryption::Key::CIPHER.dup
+          rescue OpenSSL::Cipher::CipherError => e
+            throw e unless e.message != 'not able to copy ctx'
+
+            OpenSSL::Cipher.new('aes-256-gcm')
+          end
         end
 
         def crypt(cipher_method, value)

--- a/lib/lite/encryption/schemes/deterministic.rb
+++ b/lib/lite/encryption/schemes/deterministic.rb
@@ -23,8 +23,7 @@ module Lite
           @cipher ||= begin
             Lite::Encryption::Key::CIPHER.dup
           rescue OpenSSL::Cipher::CipherError => e
-            puts e.message
-            throw e unless e.message != 'not able to copy ctx'
+            throw e unless e.message == 'not able to copy ctx'
 
             OpenSSL::Cipher.new('aes-256-gcm')
           end

--- a/lib/lite/encryption/version.rb
+++ b/lib/lite/encryption/version.rb
@@ -3,7 +3,7 @@
 module Lite
   module Encryption
 
-    VERSION = '1.2.2'
+    VERSION = '1.2.2.1-alpha'
 
   end
 end

--- a/lib/lite/encryption/version.rb
+++ b/lib/lite/encryption/version.rb
@@ -3,7 +3,7 @@
 module Lite
   module Encryption
 
-    VERSION = '1.2.2.1-alpha'
+    VERSION = '1.2.2'
 
   end
 end


### PR DESCRIPTION
Heroku throws an 'not able to copy ctx' openssl::cipher::ciphererror when using deterministic encryption on a rails 7 application. To fix this I have added a rescue to the cipher method which re-initialises when this error is thrown.